### PR TITLE
Fix everything

### DIFF
--- a/IoTBridge/Communicators/Base/AHttpCommunicator.cs
+++ b/IoTBridge/Communicators/Base/AHttpCommunicator.cs
@@ -16,8 +16,9 @@ namespace IoTBridge.Communicators.Base
         protected async Task PostAsync(string body, string endpoint)
         {
             string url = baseUrl + endpoint;
-            var content = new StringContent(body, Encoding.UTF8, "application/json");
+            var content = new StringContent(body, Encoding.ASCII, "application/json");
 
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
             var response = await httpClient.PostAsync(url, content);
             
             if (!response.IsSuccessStatusCode)
@@ -26,12 +27,11 @@ namespace IoTBridge.Communicators.Base
             }
         }
         
-        protected async Task PostAsync(Dictionary<string, string> parameters, string endpoint)
+        protected async Task PostAsync(string endpoint)
         {
             string url = baseUrl + endpoint;
-            var encodedContent = new FormUrlEncodedContent(parameters);
 
-            var response = await httpClient.PostAsync(url, encodedContent);
+            var response = await httpClient.PostAsync(url, null);
             
             if (!response.IsSuccessStatusCode)
             {

--- a/IoTBridge/Communicators/PlantApi/DTOs/Requests/PlantDataCreationListDTO.cs
+++ b/IoTBridge/Communicators/PlantApi/DTOs/Requests/PlantDataCreationListDTO.cs
@@ -2,24 +2,18 @@ using System.ComponentModel.DataAnnotations;
 
 namespace IoTBridge.Communicators.PlantApi.DTOs.Requests;
 
-public class PlantDataApi
+public class PlantDataCreationDTO
 {
     public int DeviceId { get; set; }
-    public float? Humidity { get; set; }
-
-    public float? Temperature { get; set; }
-    
+    public float Humidity { get; set; }
+    public float Temperature { get; set; }
     public float UVLight { get; set; }
-    
     public float Moisture { get; set; }
-    
-    [Key]
     public string TimeStamp { get; set; }
-
     public float TankLevel { get; set; } 
 }
 
-public class PlantDataRequest
+public class PlantDataCreationListDTO
 {
-    public List<PlantDataApi> PlantDataApi { get; set; }
+    public List<PlantDataCreationDTO> PlantDataApi { get; set; }
 }

--- a/IoTBridge/Communicators/PlantApi/Helper/PlantApiCommunicatorHelper.cs
+++ b/IoTBridge/Communicators/PlantApi/Helper/PlantApiCommunicatorHelper.cs
@@ -5,9 +5,9 @@ namespace IoTBridge.Communicators.PlantApi.Helper;
 
 public class PlantApiCommunicatorHelper
 {
-    public static PlantDataApi ConvertPlantDataToDataApi(PlantData plantData)
+    public static PlantDataCreationDTO ConvertPlantDataToDataApi(PlantData plantData)
     {
-        return new PlantDataApi()
+        return new PlantDataCreationDTO()
         {
             TimeStamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
             DeviceId = plantData.DeviceId,

--- a/IoTBridge/Communicators/PlantApi/IPlantApiCommunicator.cs
+++ b/IoTBridge/Communicators/PlantApi/IPlantApiCommunicator.cs
@@ -9,5 +9,5 @@ public interface IPlantApiCommunicator
     Task<EmptyCommunicatorResult> RegisterDevice(int deviceId);
     Task<EmptyCommunicatorResult> UpdateDeviceStatus(UpdateDeviceStatus updateDeviceStatus);
     Task<ExistingDeviceIdsResult> GetExistingDeviceIds();
-    Task<EmptyCommunicatorResult> SendPlantData(PlantDataRequest plantDataRequest);
+    Task<EmptyCommunicatorResult> SendPlantData(PlantDataCreationListDTO plantDataCreationListDto);
 }

--- a/IoTBridge/Communicators/PlantApi/PlantApiCommunicator.cs
+++ b/IoTBridge/Communicators/PlantApi/PlantApiCommunicator.cs
@@ -17,11 +17,7 @@ namespace IoTBridge.Communicators.PlantApi
         {
             try
             {
-                var parameters = new Dictionary<string, string>()
-                {
-                    { "deviceId", deviceId.ToString() }
-                };
-                await PostAsync(parameters, "device/registerDevice");
+                await PostAsync($"device/registerDevice/{deviceId}");
                 return new EmptyCommunicatorResult();
             }
             catch (Exception e)
@@ -84,9 +80,9 @@ namespace IoTBridge.Communicators.PlantApi
             }
         }
 
-        public async Task<EmptyCommunicatorResult> SendPlantData(PlantDataRequest plantDataRequest)
+        public async Task<EmptyCommunicatorResult> SendPlantData(PlantDataCreationListDTO plantDataCreationListDto)
         {
-            SerializationResult body = JsonCasterHelper.SerializeData(plantDataRequest);
+            SerializationResult body = JsonCasterHelper.SerializeData(plantDataCreationListDto);
             if (body.HasError)
             {
                 return new EmptyCommunicatorResult()

--- a/IoTBridge/DataCaching/IPlantDataApiCache.cs
+++ b/IoTBridge/DataCaching/IPlantDataApiCache.cs
@@ -4,9 +4,9 @@ namespace IoTBridge.DataCaching
 {
     public interface IPlantDataApiCache
     {
-        void CachePlantData(int connectionId, PlantDataApi dataRequest);
+        void CachePlantData(int connectionId, PlantDataCreationDTO dataRequest);
         bool HasConnectionReachedMaxCache(int connectionId, int maxCachedData);
         bool ClearCacheByConnectionId(int connectionId);
-        List<PlantDataApi> GetCachedDataByConnectionId(int connectionId);
+        List<PlantDataCreationDTO> GetCachedDataByConnectionId(int connectionId);
     }
 }

--- a/IoTBridge/DataCaching/PlantDataApiCache.cs
+++ b/IoTBridge/DataCaching/PlantDataApiCache.cs
@@ -5,18 +5,18 @@ namespace IoTBridge.DataCaching;
 public class PlantDataApiCache : IPlantDataApiCache
 {
     private readonly int memoryProtectionMaxCache;
-    private Dictionary<int, List<PlantDataApi>> plantDataByConnectionId = new();
+    private Dictionary<int, List<PlantDataCreationDTO>> plantDataByConnectionId = new();
 
     public PlantDataApiCache(int memoryProtectionMaxCache)
     {
         this.memoryProtectionMaxCache = memoryProtectionMaxCache;
     }
 
-    public void CachePlantData(int connectionId, PlantDataApi dataRequest)
+    public void CachePlantData(int connectionId, PlantDataCreationDTO dataRequest)
     {
         if (!plantDataByConnectionId.ContainsKey(connectionId))
         {
-            plantDataByConnectionId.Add(connectionId, new List<PlantDataApi>(){dataRequest});
+            plantDataByConnectionId.Add(connectionId, new List<PlantDataCreationDTO>(){dataRequest});
         }
         else
         {
@@ -35,7 +35,7 @@ public class PlantDataApiCache : IPlantDataApiCache
         return plantDataByConnectionId.ContainsKey(connectionId) && plantDataByConnectionId[connectionId].Count >= maxCachedData;
     }
     
-    public List<PlantDataApi> GetCachedDataByConnectionId(int connectionId)
+    public List<PlantDataCreationDTO> GetCachedDataByConnectionId(int connectionId)
     {
         return plantDataByConnectionId[connectionId];
     }

--- a/IoTBridge/DataProcessors/Iot/Service/IotDataProcessorService.cs
+++ b/IoTBridge/DataProcessors/Iot/Service/IotDataProcessorService.cs
@@ -38,7 +38,7 @@ namespace IoTBridge.DataProcessors.Iot.Service
                 return;
             }
 
-            List<PlantDataApi> cachedPlantData = plantDataApiCache.GetCachedDataByConnectionId(connectionId);
+            List<PlantDataCreationDTO> cachedPlantData = plantDataApiCache.GetCachedDataByConnectionId(connectionId);
             Task.Run(async () =>
             {
                 await ForwardPlantDataToApi(connectionId, cachedPlantData);
@@ -91,13 +91,14 @@ namespace IoTBridge.DataProcessors.Iot.Service
             {
                 Console.WriteLine("Generating a new id for the device...");
                 deviceId = NewIdGenerator.GenerateNewId(existingConnectionIds);
-                
+                Console.WriteLine("trying to forward the registration to plantApi...");
                 EmptyCommunicatorResult plantApiDeviceRegistrationResult = await plantApiCommunicator.RegisterDevice(deviceId);
                 if (plantApiDeviceRegistrationResult.HasError)
                 {
-                    Console.WriteLine(plantApiDeviceRegistrationResult.Error);
+                    Console.WriteLine($"Error happend in the plantapi: {plantApiDeviceRegistrationResult.Error}");
                     return;
                 }
+                Console.WriteLine("The registration happend to plantApi...");
                 Console.WriteLine($"Successfully created new id: {deviceId} for device with remote endpoint: {client.Client.RemoteEndPoint}");
             }
             else if(deviceId > 0 && !existingConnectionIds.Contains(deviceId))
@@ -147,10 +148,10 @@ namespace IoTBridge.DataProcessors.Iot.Service
             Console.WriteLine("Sending a message to start sending data...Done");
         }
 
-        private async Task ForwardPlantDataToApi(int connectionId, List<PlantDataApi> plantData)
+        private async Task ForwardPlantDataToApi(int connectionId, List<PlantDataCreationDTO> plantData)
         {
             Console.WriteLine($"Trying to forward cached plant data to api for connection: {connectionId}");
-            var plantDataRequest = new PlantDataRequest()
+            var plantDataRequest = new PlantDataCreationListDTO()
             {
                 PlantDataApi = plantData
             };

--- a/IoTBridge/IncomingData/Iot/PlantData.cs
+++ b/IoTBridge/IncomingData/Iot/PlantData.cs
@@ -3,8 +3,8 @@ namespace IoTBridge.IncomingData.Iot
     public class PlantData
     {
         public int DeviceId { get; set; }
-        public float? Humidity { get; set; }
-        public float? Temperature { get; set; }
+        public float Humidity { get; set; }
+        public float Temperature { get; set; }
         public float UVLight { get; set; }
         public float Moisture { get; set; }
         public float TankLevel { get; set; }


### PR DESCRIPTION
- changing the post method to the http client to not have the parameters and instead use proper endpoint
- changing the plant api communicator to point to device/registerDevice/{deviceId} endpoint when sending the registration request
- changing the SendPlantData to have the exact same object serialized in the body of the request as the API is requesting
- removing the ? from PlantData as we know for sure that the PlantData will not have null properties